### PR TITLE
[fix] 그라파나 대시보드 주소 영구 유지 방법으로 변경

### DIFF
--- a/frontend/src/pages/admin/Monitoring.jsx
+++ b/frontend/src/pages/admin/Monitoring.jsx
@@ -6,8 +6,11 @@ export default function Monitoring() {
   const [logs, setLogs] = useState([])
   const navigate = useNavigate()
   const { eventId } = useParams()
-  const GRAFANA_BASE_URL = import.meta.env.VITE_GRAFANA_BASE_URL || ''
-  const DASH_UID = import.meta.env.VITE_GRAFANA_DASHBOARD_UID || '';
+  const GRAFANA_BASE_URL = (import.meta.env.VITE_GRAFANA_BASE_URL || '')
+      .trim()
+      .replace(/\/+$/, '')
+
+  const DASH_UID = (import.meta.env.VITE_GRAFANA_DASHBOARD_UID || '').trim()
 
   useEffect(() => {
     const getLogs = async () => {


### PR DESCRIPTION
## 🔍 What
- 그라파나 대시보드가 url이 만료되어 뜨지 않는 현상을 수정

## 🧪 How to test
- 모든 레포를 키고 배포용 레포의 도커를 키기 전에 프로메테우스 야멜을 본인 아이피로 설정 후 도커를 실행
- 프론트를 실행 후 그라파나 대시보드가 잘 나오는지 테스트

## 🔗 Issue
- Closes: #79

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Grafana 관련 설정 입력의 앞뒤 공백 및 불필요한 슬래시를 자동 정리합니다.
  * 기본 URL뿐 아니라 대시보드 식별자(UID)도 필수로 확인해 모니터링 로드를 안정화합니다.
  * 임베드된 대시보드 로드 경로를 직접 대시보드 뷰로 전환하고 키오스크 모드 및 30초 새로고침을 적용합니다.
  * 설정 누락 시 사용자 안내 메시지를 더 명확히 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->