### PR TITLE
[fix] 어드민이 Policy를 수정해도 Queue 동작에 영향이 없는 상태를 해소

### DIFF
--- a/src/main/java/kr/gilmok/api/policy/dto/PolicyCacheDto.java
+++ b/src/main/java/kr/gilmok/api/policy/dto/PolicyCacheDto.java
@@ -14,7 +14,8 @@ public record PolicyCacheDto(
         long policyVersion,
         BlockRules blockRules,
         int maxRequestsPerSecond,
-        int blockDurationMinutes
+        int blockDurationMinutes,
+        String gateMode
 ) {
     public static PolicyCacheDto from(Policy policy) {
         return new PolicyCacheDto(
@@ -26,7 +27,8 @@ public record PolicyCacheDto(
                 policy.getPolicyVersion(),
                 policy.getBlockRules(),
                 policy.getMaxRequestsPerSecond(),
-                policy.getBlockDurationMinutes()
+                policy.getBlockDurationMinutes(),
+                policy.getGateMode()
         );
     }
 
@@ -41,7 +43,8 @@ public record PolicyCacheDto(
                 0L,
                 BlockRules.empty(),
                 0,
-                10
+                10,
+                null
         );
     }
 }

--- a/src/main/java/kr/gilmok/api/policy/dto/PolicyResponse.java
+++ b/src/main/java/kr/gilmok/api/policy/dto/PolicyResponse.java
@@ -11,7 +11,8 @@ public record PolicyResponse(
         long policyVersion,
         BlockRules blockRules,
         int maxRequestsPerSecond,
-        int blockDurationMinutes
+        int blockDurationMinutes,
+        String gateMode
 ) {
     public static PolicyResponse from(Policy policy) {
         return new PolicyResponse(
@@ -22,7 +23,8 @@ public record PolicyResponse(
                 policy.getPolicyVersion(),
                 policy.getBlockRules(),
                 policy.getMaxRequestsPerSecond(),
-                policy.getBlockDurationMinutes()
+                policy.getBlockDurationMinutes(),
+                policy.getGateMode()
         );
     }
 
@@ -35,7 +37,8 @@ public record PolicyResponse(
                 dto.policyVersion(),
                 dto.blockRules(),
                 dto.maxRequestsPerSecond(),
-                dto.blockDurationMinutes()
+                dto.blockDurationMinutes(),
+                dto.gateMode()
         );
     }
 }

--- a/src/main/java/kr/gilmok/api/queue/repository/QueueRedisRepository.java
+++ b/src/main/java/kr/gilmok/api/queue/repository/QueueRedisRepository.java
@@ -170,7 +170,8 @@ public class QueueRedisRepository {
 
     public List<Object> runAdmissionCycle(String eventId, long rate, long capacity,
                                           long admittedTtlMs, long graceMs,
-                                          int cleanupBatch, int expireBatch) {
+                                          int cleanupBatch, int expireBatch,
+                                          int maxConcurrency) {
         List<Object> result = redisTemplate.execute(
                 fastAdmissionCycleScript,
                 Arrays.asList(queueKey(eventId), admittedKey(eventId), heartbeatsKey(eventId), tokenBucketKey(eventId)),
@@ -180,7 +181,8 @@ public class QueueRedisRepository {
                 String.valueOf(admittedTtlMs),
                 String.valueOf(graceMs),
                 String.valueOf(cleanupBatch),
-                String.valueOf(expireBatch)
+                String.valueOf(expireBatch),
+                String.valueOf(maxConcurrency)
         );
         if (result == null) {
             log.error("Redis script returned null: fastAdmissionCycleScript, eventId={}", eventId);

--- a/src/main/java/kr/gilmok/api/queue/scheduler/AdmissionScheduler.java
+++ b/src/main/java/kr/gilmok/api/queue/scheduler/AdmissionScheduler.java
@@ -5,14 +5,18 @@ import io.micrometer.core.instrument.MeterRegistry;
 import kr.gilmok.api.event.entity.Event;
 import kr.gilmok.api.event.entity.EventStatus;
 import kr.gilmok.api.event.repository.EventRepository;
+import kr.gilmok.api.policy.dto.PolicyCacheDto;
+import kr.gilmok.api.policy.repository.PolicyCacheRepository;
 import kr.gilmok.api.queue.repository.QueueRedisRepository;
 import kr.gilmok.api.queue.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -22,10 +26,16 @@ public class AdmissionScheduler {
 
     private static final long ADMISSION_LOCK_TTL_MS = 5000;
 
+    private static final String ROUTING_DISABLED = "ROUTING_DISABLED";
+
     private final QueueService queueService;
     private final EventRepository eventRepository;
     private final QueueRedisRepository queueRedisRepository;
+    private final PolicyCacheRepository policyCacheRepository;
     private final MeterRegistry meterRegistry;
+
+    @Value("${queue.admission-rps:10}")
+    private int defaultAdmissionRps;
 
     @Scheduled(fixedDelay = 1000)
     public void processAdmission() {
@@ -43,7 +53,24 @@ public class AdmissionScheduler {
                             .increment();
                     continue;
                 }
-                queueService.runAdmissionCycle(eventId);
+
+                // Policy 조회 → gateMode, rps, concurrency 결정
+                int rps = defaultAdmissionRps;
+                int maxConcurrency = 0;
+                Optional<PolicyCacheDto> policyOpt = policyCacheRepository.find(event.getId());
+                if (policyOpt.isPresent() && policyOpt.get().exists()) {
+                    PolicyCacheDto policy = policyOpt.get();
+                    if (ROUTING_DISABLED.equals(policy.gateMode())) {
+                        log.debug("Admission skipped (ROUTING_DISABLED): eventId={}", eventId);
+                        continue;
+                    }
+                    if (policy.admissionRps() > 0) {
+                        rps = policy.admissionRps();
+                    }
+                    maxConcurrency = policy.admissionConcurrency();
+                }
+
+                queueService.runAdmissionCycle(eventId, rps, maxConcurrency);
             } catch (Exception e) {
                 log.error("Admission processing failed for eventId={}", eventId, e);
             } finally {

--- a/src/main/java/kr/gilmok/api/queue/service/QueueService.java
+++ b/src/main/java/kr/gilmok/api/queue/service/QueueService.java
@@ -8,6 +8,8 @@ import kr.gilmok.api.queue.dto.QueueRegisterRequest;
 import kr.gilmok.api.queue.dto.QueueRegisterResponse;
 import kr.gilmok.api.queue.dto.QueueStatusResponse;
 import kr.gilmok.api.queue.exception.QueueErrorCode;
+import kr.gilmok.api.policy.dto.PolicyCacheDto;
+import kr.gilmok.api.policy.repository.PolicyCacheRepository;
 import kr.gilmok.api.queue.repository.QueueRedisRepository;
 import kr.gilmok.api.token.service.TokenService;
 import kr.gilmok.common.exception.CustomException;
@@ -30,6 +32,7 @@ public class QueueService {
 
     private final TokenService tokenService;
     private final QueueRedisRepository queueRedisRepository;
+    private final PolicyCacheRepository policyCacheRepository;
     private final MeterRegistry meterRegistry;
 
     private final Map<String, AtomicLong> waitingQueueSizes = new ConcurrentHashMap<>();
@@ -90,7 +93,8 @@ public class QueueService {
         }
 
         long position = rank + 1;
-        long etaSeconds = position / admissionRps;
+        int effectiveRps = resolveAdmissionRps(eventId);
+        long etaSeconds = position / effectiveRps;
 
         log.info("Queue registered: eventId={}, userId={}, queueKey={}, isNew={}, position={}",
                 eventId, maskUserId(userIdStr), queueKey, isNew, position);
@@ -138,13 +142,13 @@ public class QueueService {
 
     // === 3. 통합 입장 사이클 — 반환값 기반 메트릭 (Redis 추가 호출 최소화) ===
 
-    public void runAdmissionCycle(String eventId) {
+    public void runAdmissionCycle(String eventId, int rps, int maxConcurrency) {
         long admittedTtlMs = admittedTtlSeconds * 1000L;
         long graceMs = gracePeriodSeconds * 1000L;
 
         List<Object> result = queueRedisRepository.runAdmissionCycle(
-                eventId, admissionRps, admissionRps,
-                admittedTtlMs, graceMs, 100, 100
+                eventId, rps, rps,
+                admittedTtlMs, graceMs, 100, 100, maxConcurrency
         );
 
         long expiredCount = toLong(result.get(0));
@@ -203,6 +207,21 @@ public class QueueService {
                 .tag("eventId", eventId)
                 .register(meterRegistry);
         return gauge;
+    }
+
+    // === Policy Lookup ===
+
+    private int resolveAdmissionRps(String eventId) {
+        try {
+            long evId = Long.parseLong(eventId);
+            return policyCacheRepository.find(evId)
+                    .filter(PolicyCacheDto::exists)
+                    .map(PolicyCacheDto::admissionRps)
+                    .filter(rps -> rps > 0)
+                    .orElse(admissionRps);
+        } catch (Exception e) {
+            return admissionRps;
+        }
     }
 
     // === ETA Calculation ===

--- a/src/main/resources/scripts/fast-admission-cycle.lua
+++ b/src/main/resources/scripts/fast-admission-cycle.lua
@@ -11,6 +11,7 @@
 -- ARGV[5] = gracePeriodMs
 -- ARGV[6] = cleanupBatch
 -- ARGV[7] = expireBatch
+-- ARGV[8] = maxConcurrency (0 = unlimited)
 --
 -- Returns: {expiredCount, cleanedCount, admittedCount, tokensConsumed, tokensLeft,
 --           waitingSize, admittedSize, ...admittedMembers}
@@ -27,6 +28,7 @@ local admittedTtlMs = tonumber(ARGV[4]) or 0
 local graceMs = tonumber(ARGV[5]) or 0
 local cleanupBatch = tonumber(ARGV[6]) or 100
 local expireBatch = tonumber(ARGV[7]) or 100
+local maxConcurrency = tonumber(ARGV[8]) or 0
 
 -- Guards
 if now <= 0 then
@@ -105,6 +107,27 @@ if rate > 0 and capacity > 0 and requestedMax > 0 then
   tokensLeft = tokens
 
   redis.call('HSET', bucketKey, 'tokens', tokens, 'lastRefillMs', lastRefillMs)
+end
+
+-- ------------------------------------------------------------
+-- 3.5) Concurrency limit: cap canAdmit by headroom
+-- ------------------------------------------------------------
+if maxConcurrency > 0 and canAdmit > 0 then
+  local currentAdmitted = redis.call('ZCARD', admittedKey)
+  local headroom = maxConcurrency - currentAdmitted
+  if headroom < 0 then headroom = 0 end
+  if canAdmit > headroom then
+    -- return excess tokens
+    local excess = canAdmit - headroom
+    if excess > 0 and rate > 0 and capacity > 0 then
+      local t = tokensLeft + excess
+      if t > capacity then t = capacity end
+      tokensLeft = t
+      tokensConsumed = headroom
+      redis.call('HSET', bucketKey, 'tokens', t)
+    end
+    canAdmit = headroom
+  end
 end
 
 -- ------------------------------------------------------------

--- a/src/test/java/kr/gilmok/api/policy/service/PolicyServiceTest.java
+++ b/src/test/java/kr/gilmok/api/policy/service/PolicyServiceTest.java
@@ -61,7 +61,7 @@ class PolicyServiceTest {
         @DisplayName("캐시에 있으면 Redis에서 반환하고 DB는 조회하지 않는다")
         void getPolicyByEventId_cacheHit_returnsFromRedis() {
             Long eventId = 1L;
-            PolicyCacheDto cached = new PolicyCacheDto(true, eventId, 10, 5, 300L, 2L, BlockRules.empty(), 20, 10);
+            PolicyCacheDto cached = new PolicyCacheDto(true, eventId, 10, 5, 300L, 2L, BlockRules.empty(), 20, 10, "ROUTING_ENABLED");
             when(policyCacheRepository.find(eventId)).thenReturn(Optional.of(cached));
 
             PolicyResponse response = policyService.getPolicyByEventId(eventId);

--- a/src/test/java/kr/gilmok/api/queue/repository/QueueRedisRepositoryIntegrationTest.java
+++ b/src/test/java/kr/gilmok/api/queue/repository/QueueRedisRepositoryIntegrationTest.java
@@ -84,7 +84,7 @@ class QueueRedisRepositoryIntegrationTest {
     void registerIdempotent_admittedUser_returnsBlocked() {
         // given — 등록 후 입장
         queueRedisRepository.registerIdempotent(EVENT_ID, "user-1", "qk-1", 1.0, 600);
-        queueRedisRepository.runAdmissionCycle(EVENT_ID, 10, 10, 300_000, 180_000, 100, 100);
+        queueRedisRepository.runAdmissionCycle(EVENT_ID, 10, 10, 300_000, 180_000, 100, 100, 0);
 
         // when — 같은 userId로 재등록 시도
         List<Object> result = queueRedisRepository.registerIdempotent(
@@ -102,7 +102,7 @@ class QueueRedisRepositoryIntegrationTest {
     void getStatusAtomic_admitted_returnsCode1() {
         // given
         queueRedisRepository.registerIdempotent(EVENT_ID, "user-1", "qk-1", 1.0, 600);
-        queueRedisRepository.runAdmissionCycle(EVENT_ID, 10, 10, 300_000, 180_000, 100, 100);
+        queueRedisRepository.runAdmissionCycle(EVENT_ID, 10, 10, 300_000, 180_000, 100, 100, 0);
 
         // when
         List<Long> result = queueRedisRepository.getStatusAtomic(EVENT_ID, "qk-1", 60);
@@ -149,7 +149,7 @@ class QueueRedisRepositoryIntegrationTest {
 
         // when
         List<Object> result = queueRedisRepository.runAdmissionCycle(
-                EVENT_ID, 10, 10, 300_000, 180_000, 100, 100);
+                EVENT_ID, 10, 10, 300_000, 180_000, 100, 100, 0);
 
         // then — 최소 7개 + admitted members
         assertThat(result.size()).isGreaterThanOrEqualTo(7);
@@ -223,7 +223,7 @@ class QueueRedisRepositoryIntegrationTest {
 
         // when
         List<Object> result = queueRedisRepository.runAdmissionCycle(
-                EVENT_ID, 10, 10, ttlMs, 180_000, 100, 100);
+                EVENT_ID, 10, 10, ttlMs, 180_000, 100, 100, 0);
 
         // then
         long expiredCount = toLong(result.get(0));
@@ -244,7 +244,7 @@ class QueueRedisRepositoryIntegrationTest {
 
         // when — capacity=10이므로 첫 사이클에서 최대 10명만 입장
         List<Object> result1 = queueRedisRepository.runAdmissionCycle(
-                EVENT_ID, 10, 10, 300_000, 180_000, 100, 100);
+                EVENT_ID, 10, 10, 300_000, 180_000, 100, 100, 0);
 
         // then
         long admitted1 = toLong(result1.get(2));
@@ -253,7 +253,7 @@ class QueueRedisRepositoryIntegrationTest {
 
         // when — 즉시 두 번째 사이클 (토큰 미리필)
         List<Object> result2 = queueRedisRepository.runAdmissionCycle(
-                EVENT_ID, 10, 10, 300_000, 180_000, 100, 100);
+                EVENT_ID, 10, 10, 300_000, 180_000, 100, 100, 0);
 
         // then — 토큰이 거의 없으므로 입장 제한
         long admitted2 = toLong(result2.get(2));

--- a/src/test/java/kr/gilmok/api/queue/scheduler/AdmissionSchedulerTest.java
+++ b/src/test/java/kr/gilmok/api/queue/scheduler/AdmissionSchedulerTest.java
@@ -5,6 +5,9 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import kr.gilmok.api.event.entity.Event;
 import kr.gilmok.api.event.entity.EventStatus;
 import kr.gilmok.api.event.repository.EventRepository;
+import kr.gilmok.api.policy.dto.PolicyCacheDto;
+import kr.gilmok.api.policy.repository.PolicyCacheRepository;
+import kr.gilmok.api.policy.vo.BlockRules;
 import kr.gilmok.api.queue.repository.QueueRedisRepository;
 import kr.gilmok.api.queue.service.QueueService;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,8 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -33,13 +38,19 @@ class AdmissionSchedulerTest {
     @Mock
     private QueueRedisRepository queueRedisRepository;
 
+    @Mock
+    private PolicyCacheRepository policyCacheRepository;
+
     private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     private AdmissionScheduler admissionScheduler;
 
     @BeforeEach
     void setUp() {
-        admissionScheduler = new AdmissionScheduler(queueService, eventRepository, queueRedisRepository, meterRegistry);
+        admissionScheduler = new AdmissionScheduler(
+                queueService, eventRepository, queueRedisRepository,
+                policyCacheRepository, meterRegistry);
+        ReflectionTestUtils.setField(admissionScheduler, "defaultAdmissionRps", 10);
     }
 
     private Event createEvent(Long id) {
@@ -59,12 +70,13 @@ class AdmissionSchedulerTest {
                 .willReturn(true);
         given(queueRedisRepository.unlock(eq("1"), anyString()))
                 .willReturn(true);
+        given(policyCacheRepository.find(1L)).willReturn(Optional.empty());
 
         // when
         admissionScheduler.processAdmission();
 
         // then
-        verify(queueService).runAdmissionCycle("1");
+        verify(queueService).runAdmissionCycle("1", 10, 0);
         verify(queueRedisRepository).unlock(eq("1"), anyString());
     }
 
@@ -82,7 +94,7 @@ class AdmissionSchedulerTest {
         admissionScheduler.processAdmission();
 
         // then
-        verify(queueService, never()).runAdmissionCycle(anyString());
+        verify(queueService, never()).runAdmissionCycle(anyString(), anyInt(), anyInt());
         verify(queueRedisRepository, never()).unlock(anyString(), anyString());
         double skipCount = meterRegistry.get("queue.admission.lock.skipped")
                 .tag("eventId", "1")
@@ -100,13 +112,62 @@ class AdmissionSchedulerTest {
                 .willReturn(List.of(event));
         given(queueRedisRepository.tryLock(eq("1"), anyString(), eq(5000L)))
                 .willReturn(true);
+        given(policyCacheRepository.find(1L)).willReturn(Optional.empty());
         doThrow(new RuntimeException("test error"))
-                .when(queueService).runAdmissionCycle("1");
+                .when(queueService).runAdmissionCycle("1", 10, 0);
 
         // when
         admissionScheduler.processAdmission();
 
         // then
         verify(queueRedisRepository).unlock(eq("1"), anyString());
+    }
+
+    @Test
+    @DisplayName("gateMode=ROUTING_DISABLED이면 admission cycle이 스킵된다")
+    void processAdmission_routingDisabled_skipsCycle() {
+        // given
+        Event event = createEvent(1L);
+        given(eventRepository.findByStatusOrderByStartsAtDesc(EventStatus.OPEN))
+                .willReturn(List.of(event));
+        given(queueRedisRepository.tryLock(eq("1"), anyString(), eq(5000L)))
+                .willReturn(true);
+        given(queueRedisRepository.unlock(eq("1"), anyString()))
+                .willReturn(true);
+
+        PolicyCacheDto disabledPolicy = new PolicyCacheDto(
+                true, 1L, 20, 500, 300L, 1L,
+                BlockRules.empty(), 0, 10, "ROUTING_DISABLED");
+        given(policyCacheRepository.find(1L)).willReturn(Optional.of(disabledPolicy));
+
+        // when
+        admissionScheduler.processAdmission();
+
+        // then
+        verify(queueService, never()).runAdmissionCycle(anyString(), anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("Policy에 admissionRps/Concurrency 설정 시 해당 값으로 전달된다")
+    void processAdmission_withPolicy_usesValues() {
+        // given
+        Event event = createEvent(1L);
+        given(eventRepository.findByStatusOrderByStartsAtDesc(EventStatus.OPEN))
+                .willReturn(List.of(event));
+        given(queueRedisRepository.tryLock(eq("1"), anyString(), eq(5000L)))
+                .willReturn(true);
+        given(queueRedisRepository.unlock(eq("1"), anyString()))
+                .willReturn(true);
+
+        PolicyCacheDto policy = new PolicyCacheDto(
+                true, 1L, 20, 500, 300L, 1L,
+                BlockRules.empty(), 0, 10, "ROUTING_ENABLED");
+        given(policyCacheRepository.find(1L)).willReturn(Optional.of(policy));
+
+        // when
+        admissionScheduler.processAdmission();
+
+        // then
+        verify(queueService).runAdmissionCycle("1", 20, 500);
     }
 }

--- a/src/test/java/kr/gilmok/api/queue/service/QueueServiceTest.java
+++ b/src/test/java/kr/gilmok/api/queue/service/QueueServiceTest.java
@@ -4,6 +4,7 @@ import kr.gilmok.api.queue.QueueStatus;
 import kr.gilmok.api.queue.dto.QueueRegisterRequest;
 import kr.gilmok.api.queue.dto.QueueRegisterResponse;
 import kr.gilmok.api.queue.dto.QueueStatusResponse;
+import kr.gilmok.api.policy.repository.PolicyCacheRepository;
 import kr.gilmok.api.queue.repository.QueueRedisRepository;
 import kr.gilmok.api.token.service.TokenService;
 import kr.gilmok.common.exception.CustomException;
@@ -33,6 +34,8 @@ class QueueServiceTest {
     private TokenService tokenService;
     @Mock
     private QueueRedisRepository queueRedisRepository;
+    @Mock
+    private PolicyCacheRepository policyCacheRepository;
 
     private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
@@ -43,7 +46,7 @@ class QueueServiceTest {
 
     @BeforeEach
     void setUp() {
-        queueService = new QueueService(tokenService, queueRedisRepository, meterRegistry);
+        queueService = new QueueService(tokenService, queueRedisRepository, policyCacheRepository, meterRegistry);
         ReflectionTestUtils.setField(queueService, "admissionRps", 10);
         ReflectionTestUtils.setField(queueService, "admittedTtlSeconds", 300);
         ReflectionTestUtils.setField(queueService, "gracePeriodSeconds", 180);
@@ -253,11 +256,11 @@ class QueueServiceTest {
         // given — 결과: expired=2, cleaned=1, admitted=3, consumed=3, left=7, waiting=5, admittedSize=3, members
         given(queueRedisRepository.runAdmissionCycle(
                 eq("event1"), anyLong(), anyLong(),
-                eq(300_000L), eq(180_000L), eq(100), eq(100)
+                eq(300_000L), eq(180_000L), eq(100), eq(100), eq(0)
         )).willReturn(Arrays.asList(2L, 1L, 3L, 3L, 7L, 5L, 3L, "m1", "m2", "m3"));
 
         // when
-        queueService.runAdmissionCycle("event1");
+        queueService.runAdmissionCycle("event1", 10, 0);
 
         // then
         verify(queueRedisRepository).recordAdmissionRate(eq("event1"), eq(3L), anyLong());
@@ -270,11 +273,11 @@ class QueueServiceTest {
         // given — 모두 0
         given(queueRedisRepository.runAdmissionCycle(
                 eq("event1"), anyLong(), anyLong(),
-                eq(300_000L), eq(180_000L), eq(100), eq(100)
+                eq(300_000L), eq(180_000L), eq(100), eq(100), eq(0)
         )).willReturn(Arrays.asList(0L, 0L, 0L, 0L, 10L, 5L, 0L));
 
         // when
-        queueService.runAdmissionCycle("event1");
+        queueService.runAdmissionCycle("event1", 10, 0);
 
         // then
         verify(queueRedisRepository, never()).recordAdmissionRate(anyString(), anyLong(), anyLong());
@@ -287,11 +290,11 @@ class QueueServiceTest {
         // given
         given(queueRedisRepository.runAdmissionCycle(
                 eq("event1"), anyLong(), anyLong(),
-                eq(300_000L), eq(180_000L), eq(100), eq(100)
+                eq(300_000L), eq(180_000L), eq(100), eq(100), eq(0)
         )).willReturn(Arrays.asList(0L, 0L, 0L, 0L, 10L, 42L, 7L));
 
         // when
-        queueService.runAdmissionCycle("event1");
+        queueService.runAdmissionCycle("event1", 10, 0);
 
         // then — getQueueSize/getAdmittedCount 호출 없어야 함 (반환값 사용)
         verify(queueRedisRepository, never()).getQueueSize("event1");


### PR DESCRIPTION
## 🔍 What

  어드민이 Policy(admissionRps, admissionConcurrency, gateMode)를 수정하면 Queue 입장 동작에 실시간 반영되도록 연동합니다.
  기존에는 `application.yml`의 글로벌 `@Value`만 사용하여 Policy 변경이 무시되던 문제를 해소합니다.

  ### 변경 사항
  - **PolicyCacheDto / PolicyResponse**: `gateMode` 필드 추가
  - **fast-admission-cycle.lua**: `ARGV[8] maxConcurrency` 동시접속 제한 로직 (0이면 무제한)
  - **QueueRedisRepository**: `runAdmissionCycle`에 `maxConcurrency` 파라미터 추가
  - **AdmissionScheduler**: `PolicyCacheRepository` 주입, 이벤트별 Policy 조회 후 rps/concurrency/gateMode 반영
  - **QueueService**: `runAdmissionCycle(eventId, rps, maxConcurrency)` 파라미터화 + register ETA에 이벤트별 rps 사용

  ### Fallback 전략
  | 상황 | 동작 |
  |------|------|
  | Policy 없음 / admissionRps == 0 | @Value 기본값 사용 |
  | admissionConcurrency == 0 | 동시접속 제한 없음 |
  | gateMode == ROUTING_DISABLED | admission cycle 스킵 |

  ## 🧪 How to test
  1. `./gradlew :test` — AdmissionSchedulerTest 5개, QueueServiceTest register/runAdmission 6개 통과 확인
  2. Policy.admissionRps 변경 → 해당 이벤트 입장 속도 반영
  3. gateMode=ROUTING_DISABLED 설정 → admission cycle 스킵 (로그 확인)
  4. Policy.admissionConcurrency 설정 → 동시접속 수 제한 동작

  ## 🔗 Issue
  - Closes: #95 

---
### ✅ 체크리스트
- [ ] base가 **develop**으로 설정되었나요?
- [ ] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 정책 기반의 입장 제어 시스템 추가: 라우팅 활성화/비활성화 옵션과 동적 요청 레이트 조절 지원
  * 동시 접속 수 제한 기능 추가: 최대 동시 접속 수를 정책에 따라 제한하고 관리

* **개선 사항**
  * 정책 데이터 구조 확장으로 더 세밀한 트래픽 제어 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->