### PR TITLE
[fix] PolicyFilter 개선 (AbortPolicy, Redis 예외, JSON 직렬화)

### DIFF
--- a/src/main/java/kr/gilmok/api/policy/filter/PolicyFilter.java
+++ b/src/main/java/kr/gilmok/api/policy/filter/PolicyFilter.java
@@ -173,7 +173,7 @@ public class PolicyFilter extends OncePerRequestFilter {
             }
         } catch (DataAccessException e) {
             // Redis 장애 시에만 Fail-Open (차단/rate limit 건너뛰고 통과)
-            log.error("[PolicyFilter] Redis error during policy enforcement (Fail-Open): eventId={}, {}", eventId, e.getMessage());
+            log.error("[PolicyFilter] Redis error during policy enforcement (Fail-Open): eventId={}", eventId, e);
         }
 
         filterChain.doFilter(wrappedRequest, response);


### PR DESCRIPTION
## 🔍 What
- PolicyFilter 코드리뷰 반영: Executor를 AbortPolicy로 바꾸고, 큐 포화 시 RejectedExecutionException을 잡아 매칭 실패로 처리했습니다.
- Redis fail-open은 DataAccessException만 catch하도록 범위를 좁히고, sendError 응답 body는 ObjectMapper로 JSON 직렬화하도록 수정했습니다.
- ReDoS 방지를 위해 Pattern.compile()도 executor에서 타임아웃으로 실행하도록 했습니다.

## 🧪 How to test
- 기존 PolicyFilter 동작(차단 규칙 403, rate limit 429, Redis 장애 시 통과)이 그대로인지 확인합니다.
- Redis 중단 후 요청이 통과(fail-open)되는지, 에러 로그에 Redis 관련 메시지만 나오는지 확인합니다.
- 4xx/429 응답 body가 {"message":"..."} 형태의 유효한 JSON인지 확인합니다.

## 🔗 Issue
- Closes: #126 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 버그 수정
* 타임아웃 보호로 요청 처리 지연 완화 및 시스템 안정성 향상
* 캐시/데이터 저장소 오류 처리 강화로 실패 시 안전한 동작 보장
* 과부하 상황에서 빠르게 실패(fail-fast)하도록 개선되어 리소스 고갈 방지
* 오류 응답 생성 방식 개선으로 일관된 에러 응답 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->