### PR TITLE
[fix] 대기열 진입 속도 개선

### DIFF
--- a/src/main/java/kr/gilmok/api/config/RedisConfig.java
+++ b/src/main/java/kr/gilmok/api/config/RedisConfig.java
@@ -100,4 +100,12 @@ public class RedisConfig {
         script.setResultType(Long.class);
         return script;
     }
+
+    @Bean
+    public DefaultRedisScript<Long> policyEnforceScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setScriptSource(new ResourceScriptSource(new ClassPathResource("scripts/policy-enforce.lua")));
+        script.setResultType(Long.class);
+        return script;
+    }
 }

--- a/src/main/java/kr/gilmok/api/policy/filter/PolicyFilter.java
+++ b/src/main/java/kr/gilmok/api/policy/filter/PolicyFilter.java
@@ -15,15 +15,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -45,6 +46,9 @@ public class PolicyFilter extends OncePerRequestFilter {
 
     private static final String QUEUE_PATH_PREFIX = "/queue/";
     private static final String QUEUE_REGISTER_PATH = "/queue/register";
+
+    /** PolicyFilter → Controller 간 정책 전달용 request attribute 키 */
+    public static final String POLICY_CACHE_ATTR = "policyCache";
 
     private static final String BLOCK_KEY_PREFIX = "policy:block:";
     private static final String RATE_LIMIT_KEY_PREFIX = "policy:rl:";
@@ -102,6 +106,7 @@ public class PolicyFilter extends OncePerRequestFilter {
     private final PolicyCacheRepository policyCacheRepository;
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    private final DefaultRedisScript<Long> policyEnforceScript;
 
     @Value("${app.policy.trust-forwarded-for:false}")
     private boolean trustForwardedFor;
@@ -154,16 +159,7 @@ public class PolicyFilter extends OncePerRequestFilter {
 
         String blockKey = BLOCK_KEY_PREFIX + eventId + ":" + clientKey;
 
-        try {
-            if (Boolean.TRUE.equals(redisTemplate.hasKey(blockKey))) {
-                log.debug("[PolicyFilter] Request from blocked client: eventId={}, key={}", eventId, clientKey);
-                sendError(response, 429, "Too many requests; temporarily blocked");
-                return;
-            }
-        } catch (DataAccessException e) {
-            log.error("[PolicyFilter] Redis error while checking block key (Fail-Open): eventId={}", eventId, e);
-        }
-
+        // 1. 차단 규칙 확인 (Regex + Fail-Close timeout escalation)
         try {
             RuleCheckResult ruleResult = blockedByRules(eventId, clientKey, blockKey, policy.blockRules(), path, clientIp, userAgent);
 
@@ -193,29 +189,36 @@ public class PolicyFilter extends OncePerRequestFilter {
             return;
         }
 
+        // 2. Block check + Rate limit — single Lua call (EXISTS + INCR/EXPIRE + SET)
         try {
             int maxRps = policy.maxRequestsPerSecond();
-            if (maxRps > 0) {
-                long currentSecond = System.currentTimeMillis() / 1000;
-                String rlKey = RATE_LIMIT_KEY_PREFIX + eventId + ":" + clientKey + ":" + currentSecond;
+            long currentSecond = System.currentTimeMillis() / 1000;
+            String rlKey = RATE_LIMIT_KEY_PREFIX + eventId + ":" + clientKey + ":" + currentSecond;
+            int blockSeconds = policy.blockDurationMinutes() * 60;
 
-                Long count = incrementWithExpire(rlKey, 2L);
+            Long enforceResult = redisTemplate.execute(policyEnforceScript,
+                    List.of(blockKey, rlKey),
+                    String.valueOf(maxRps), String.valueOf(blockSeconds));
 
-                if (count != null && count > maxRps) {
-                    int blockMinutes = policy.blockDurationMinutes();
-                    if (blockMinutes > 0) {
-                        redisTemplate.opsForValue().set(blockKey, "1", blockMinutes, TimeUnit.MINUTES);
-                    }
-                    log.warn("[PolicyFilter] Rate limit exceeded, blocking: eventId={}, key={}, count={}, maxRps={}, blockMin={}",
-                            eventId, clientKey, count, maxRps, blockMinutes);
-                    sendError(response, 429, "Too many requests; temporarily blocked");
-                    return;
+            if (enforceResult != null && enforceResult > 0) {
+                String maskedKey = maskClientKey(clientKey);
+                if (enforceResult == 1) {
+                    log.debug("[PolicyFilter] Request from blocked client: eventId={}, key={}", eventId, maskedKey);
+                } else if (enforceResult == 2) {
+                    log.warn("[PolicyFilter] Rate limit exceeded, client blocked: eventId={}, key={}, maxRps={}, blockSec={}",
+                            eventId, maskedKey, maxRps, blockSeconds);
+                } else {
+                    log.warn("[PolicyFilter] Rate limit exceeded (no block configured): eventId={}, key={}, maxRps={}",
+                            eventId, maskedKey, maxRps);
                 }
+                sendError(response, 429, "Too many requests; temporarily blocked");
+                return;
             }
         } catch (DataAccessException e) {
             log.error("[PolicyFilter] Redis error during policy enforcement (Fail-Open): eventId={}", eventId, e);
         }
 
+        wrappedRequest.setAttribute(POLICY_CACHE_ATTR, policy);
         filterChain.doFilter(wrappedRequest, response);
     }
 
@@ -347,7 +350,6 @@ public class PolicyFilter extends OncePerRequestFilter {
             log.warn("[PolicyFilter] Regex match interrupted");
             return MatchOutcome.NOT_MATCHED;
         } catch (TimeoutException e) {
-            // cancel(true)는 get() 대기를 해제할 뿐, java.util.regex 실행 자체를 즉시 중단한다고 보장하지 않음
             future.cancel(true);
             log.warn("[PolicyFilter] Regex match timeout: regexLength={}, inputLength={}, mode={}",
                     regex.length(),
@@ -403,8 +405,9 @@ public class PolicyFilter extends OncePerRequestFilter {
         try {
             Long timeoutCount = incrementWithExpire(timeoutKey, REGEX_TIMEOUT_WINDOW_SECONDS);
 
+            String maskedKey = maskClientKey(clientKey);
             log.warn("[PolicyFilter] Regex timeout detected: eventId={}, ruleType={}, path={}, key={}, ip={}, ua={}, timeoutCount={}",
-                    eventId, ruleType, path, clientKey, maskIp(clientIp), userAgent, timeoutCount);
+                    eventId, ruleType, path, maskedKey, maskIp(clientIp), userAgent, timeoutCount);
 
             if (timeoutCount != null && timeoutCount >= REGEX_TIMEOUT_THRESHOLD) {
                 redisTemplate.opsForValue().set(
@@ -415,7 +418,7 @@ public class PolicyFilter extends OncePerRequestFilter {
                 );
 
                 log.warn("[PolicyFilter] Client temporarily blocked by repeated regex timeouts: eventId={}, ruleType={}, key={}, count={}",
-                        eventId, ruleType, clientKey, timeoutCount);
+                        eventId, ruleType, maskedKey, timeoutCount);
                 return true;
             }
 
@@ -460,6 +463,20 @@ public class PolicyFilter extends OncePerRequestFilter {
             return "***";
         }
         return ip.substring(0, ip.length() / 2) + "***";
+    }
+
+    /** clientKey("u:{id}" 또는 "ip:{addr}")의 값 부분을 마스킹. 예: "u:123" → "u:***", "ip:10.0.0.1" → "ip:10.***" */
+    private String maskClientKey(String clientKey) {
+        if (clientKey == null) return "***";
+        int colonIdx = clientKey.indexOf(':');
+        if (colonIdx < 0 || colonIdx + 1 >= clientKey.length()) return "***";
+        String prefix = clientKey.substring(0, colonIdx + 1);
+        String value = clientKey.substring(colonIdx + 1);
+        if (prefix.startsWith("ip:")) {
+            return prefix + maskIp(value);
+        }
+        // userId: 전부 마스킹
+        return prefix + "***";
     }
 
     private void sendError(HttpServletResponse response, int status, String message) throws IOException {

--- a/src/main/java/kr/gilmok/api/queue/controller/QueueController.java
+++ b/src/main/java/kr/gilmok/api/queue/controller/QueueController.java
@@ -1,7 +1,11 @@
 package kr.gilmok.api.queue.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import kr.gilmok.api.policy.dto.PolicyCacheDto;
+import kr.gilmok.api.policy.filter.PolicyFilter;
 import kr.gilmok.api.queue.dto.QueueRegisterRequest;
+import lombok.extern.slf4j.Slf4j;
 import kr.gilmok.api.queue.dto.QueueRegisterResponse;
 import kr.gilmok.api.queue.dto.QueueStatusResponse;
 import kr.gilmok.api.queue.service.QueueService;
@@ -13,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/queue")
 @RequiredArgsConstructor
@@ -23,9 +28,15 @@ public class QueueController {
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<QueueRegisterResponse>> register(
             @AuthenticationPrincipal CustomUserDetails principal,
-            @Valid @RequestBody QueueRegisterRequest request) {
+            @Valid @RequestBody QueueRegisterRequest request,
+            HttpServletRequest httpRequest) {
         Long userId = principal.user().id();
-        QueueRegisterResponse response = queueService.register(userId, request);
+        // PolicyFilter가 정책 조회 결과를 request attribute로 전달 (eventId 미추출·정책 미존재 시 null)
+        PolicyCacheDto policy = (PolicyCacheDto) httpRequest.getAttribute(PolicyFilter.POLICY_CACHE_ATTR);
+        if (policy == null) {
+            log.debug("policyCache not set by PolicyFilter, falling back to default RPS");
+        }
+        QueueRegisterResponse response = queueService.register(userId, request, policy);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 

--- a/src/main/java/kr/gilmok/api/queue/service/QueueService.java
+++ b/src/main/java/kr/gilmok/api/queue/service/QueueService.java
@@ -9,7 +9,6 @@ import kr.gilmok.api.queue.dto.QueueRegisterResponse;
 import kr.gilmok.api.queue.dto.QueueStatusResponse;
 import kr.gilmok.api.queue.exception.QueueErrorCode;
 import kr.gilmok.api.policy.dto.PolicyCacheDto;
-import kr.gilmok.api.policy.repository.PolicyCacheRepository;
 import kr.gilmok.api.queue.repository.QueueRedisRepository;
 import kr.gilmok.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class QueueService {
 
     private final QueueRedisRepository queueRedisRepository;
-    private final PolicyCacheRepository policyCacheRepository;
     private final MeterRegistry meterRegistry;
 
     private final Map<String, AtomicLong> waitingQueueSizes = new ConcurrentHashMap<>();
@@ -63,7 +61,7 @@ public class QueueService {
 
     // === 1. 대기열 등록 (멱등 + admitted 차단) — 1 Redis 호출 ===
 
-    public QueueRegisterResponse register(Long userId, QueueRegisterRequest request) {
+    public QueueRegisterResponse register(Long userId, QueueRegisterRequest request, PolicyCacheDto policy) {
         if (userId == null) {
            throw new IllegalArgumentException("userId must not be null");
         }
@@ -87,11 +85,13 @@ public class QueueService {
         }
 
         if (isNew == 1) {
-            updateMetrics(eventId);
+            long waitingSize = toLong(result.get(3));
+            long admittedSize = toLong(result.get(4));
+            updateMetricsFromValues(eventId, waitingSize, admittedSize);
         }
 
         long position = rank + 1;
-        int effectiveRps = resolveAdmissionRps(eventId);
+        int effectiveRps = resolveAdmissionRps(policy);
         long etaSeconds = position / effectiveRps;
 
         log.info("Queue registered: eventId={}, userId={}, queueKey={}, isNew={}, position={}",
@@ -206,17 +206,11 @@ public class QueueService {
 
     // === Policy Lookup ===
 
-    private int resolveAdmissionRps(String eventId) {
-        try {
-            long evId = Long.parseLong(eventId);
-            return policyCacheRepository.find(evId)
-                    .filter(PolicyCacheDto::exists)
-                    .map(PolicyCacheDto::admissionRps)
-                    .filter(rps -> rps > 0)
-                    .orElse(admissionRps);
-        } catch (Exception e) {
-            return admissionRps;
+    private int resolveAdmissionRps(PolicyCacheDto policy) {
+        if (policy != null && policy.exists() && policy.admissionRps() > 0) {
+            return policy.admissionRps();
         }
+        return admissionRps;
     }
 
     // === ETA Calculation ===

--- a/src/main/resources/scripts/policy-enforce.lua
+++ b/src/main/resources/scripts/policy-enforce.lua
@@ -1,0 +1,42 @@
+-- Policy enforcement: block check + rate limit in a single call
+-- KEYS[1] = blockKey (e.g. policy:block:{eventId}:{clientKey})
+-- KEYS[2] = rlKey    (e.g. policy:rl:{eventId}:{clientKey}:{second})
+--
+-- ARGV[1] = maxRps (0 = rate limiting disabled)
+-- ARGV[2] = blockDurationSeconds (0 = no auto-block on exceed)
+--
+-- Returns:
+--   0 = allowed
+--   1 = already blocked
+--   2 = rate limit exceeded (block created)
+--   3 = rate limit exceeded (no block configured)
+
+local blockKey = KEYS[1]
+local rlKey    = KEYS[2]
+local maxRps              = tonumber(ARGV[1]) or 0
+local blockDurationSeconds = tonumber(ARGV[2]) or 0
+
+-- 1. Check existing block
+if redis.call('EXISTS', blockKey) == 1 then
+    return 1
+end
+
+-- 2. Rate limit (skip if disabled)
+if maxRps <= 0 then
+    return 0
+end
+
+local count = redis.call('INCR', rlKey)
+if count == 1 then
+    redis.call('EXPIRE', rlKey, 2)
+end
+
+if count > maxRps then
+    if blockDurationSeconds > 0 then
+        redis.call('SET', blockKey, '1', 'EX', blockDurationSeconds)
+        return 2
+    end
+    return 3
+end
+
+return 0

--- a/src/main/resources/scripts/register-idempotent.lua
+++ b/src/main/resources/scripts/register-idempotent.lua
@@ -12,7 +12,7 @@
 -- ARGV[5] = sessionTtlSeconds
 -- ARGV[6] = eventId
 --
--- Returns: {isNew, queueKeyString, rank}
+-- Returns: {isNew, queueKeyString, rank, waitingSize, admittedSize}
 --   isNew: -1 = already admitted (blocked), 0 = existing waiting (idempotent), 1 = newly registered
 
 local queueKey           = KEYS[1]
@@ -51,14 +51,14 @@ if existing then
   local admScore = redis.call('ZSCORE', admittedKey, existing)
   if admScore then
     upsertSession(existing, 'ADMITTED')
-    return {-1, existing, -1}
+    return {-1, existing, -1, redis.call('ZCARD', queueKey), redis.call('ZCARD', admittedKey)}
   end
 
   -- b) Still in waiting queue → session upsert (WAITING) + return idempotent
   local existingRank = redis.call('ZRANK', queueKey, existing)
   if existingRank ~= false and existingRank ~= nil then
     upsertSession(existing, 'WAITING')
-    return {0, existing, existingRank}
+    return {0, existing, existingRank, redis.call('ZCARD', queueKey), redis.call('ZCARD', admittedKey)}
   end
 
   -- c) Both gone (expired) → clean up index and re-register below
@@ -80,4 +80,4 @@ upsertSession(newQueueKeyVal, 'WAITING')
 local newRank = redis.call('ZRANK', queueKey, newQueueKeyVal)
 if newRank == false or newRank == nil then newRank = 0 end
 
-return {1, newQueueKeyVal, newRank}
+return {1, newQueueKeyVal, newRank, redis.call('ZCARD', queueKey), redis.call('ZCARD', admittedKey)}

--- a/src/test/java/kr/gilmok/api/queue/service/QueueServiceTest.java
+++ b/src/test/java/kr/gilmok/api/queue/service/QueueServiceTest.java
@@ -2,7 +2,7 @@ package kr.gilmok.api.queue.service;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import kr.gilmok.api.policy.repository.PolicyCacheRepository;
+import kr.gilmok.api.policy.dto.PolicyCacheDto;
 import kr.gilmok.api.queue.QueueStatus;
 import kr.gilmok.api.queue.dto.QueueRegisterRequest;
 import kr.gilmok.api.queue.dto.QueueRegisterResponse;
@@ -30,8 +30,6 @@ class QueueServiceTest {
 
     @Mock
     private QueueRedisRepository queueRedisRepository;
-    @Mock
-    private PolicyCacheRepository policyCacheRepository;
 
     private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
@@ -39,10 +37,12 @@ class QueueServiceTest {
 
     private static final Long USER_ID = 1L;
     private static final String USER_ID_STR = "1";
+    private static final PolicyCacheDto TEST_POLICY = new PolicyCacheDto(
+            true, 1L, 10, 0, 1L, null, 0, 10, "ROUTING_ENABLED");
 
     @BeforeEach
     void setUp() {
-        queueService = new QueueService(queueRedisRepository, policyCacheRepository, meterRegistry);
+        queueService = new QueueService(queueRedisRepository, meterRegistry);
         ReflectionTestUtils.setField(queueService, "admissionRps", 10);
         ReflectionTestUtils.setField(queueService, "admittedTtlSeconds", 300);
         ReflectionTestUtils.setField(queueService, "gracePeriodSeconds", 180);
@@ -70,16 +70,19 @@ class QueueServiceTest {
         QueueRegisterRequest request = createRequest("event1");
         given(queueRedisRepository.registerIdempotent(
                 eq("event1"), eq(USER_ID_STR), anyString(), anyDouble(), anyInt()))
-                .willReturn(Arrays.asList(1L, "new-queue-key", 0L));
+                .willReturn(Arrays.asList(1L, "new-queue-key", 0L, 100L, 50L));
 
         // when
-        QueueRegisterResponse response = queueService.register(USER_ID, request);
+        QueueRegisterResponse response = queueService.register(USER_ID, request, TEST_POLICY);
 
         // then
         assertThat(response.getQueueKey()).isEqualTo("new-queue-key");
         assertThat(response.getPosition()).isEqualTo(1);
         verify(queueRedisRepository).registerIdempotent(
                 eq("event1"), eq(USER_ID_STR), anyString(), anyDouble(), anyInt());
+        // metrics come from Lua return values — no extra Redis calls
+        verify(queueRedisRepository, never()).getQueueSize(anyString());
+        verify(queueRedisRepository, never()).getAdmittedCount(anyString());
     }
 
     @Test
@@ -89,10 +92,10 @@ class QueueServiceTest {
         QueueRegisterRequest request = createRequest("event1");
         given(queueRedisRepository.registerIdempotent(
                 eq("event1"), eq(USER_ID_STR), anyString(), anyDouble(), anyInt()))
-                .willReturn(Arrays.asList(0L, "existing-queue-key", 5L));
+                .willReturn(Arrays.asList(0L, "existing-queue-key", 5L, 100L, 50L));
 
         // when
-        QueueRegisterResponse response = queueService.register(USER_ID, request);
+        QueueRegisterResponse response = queueService.register(USER_ID, request, TEST_POLICY);
 
         // then
         assertThat(response.getQueueKey()).isEqualTo("existing-queue-key");
@@ -108,15 +111,49 @@ class QueueServiceTest {
         QueueRegisterRequest request = createRequest("event1");
         given(queueRedisRepository.registerIdempotent(
                 eq("event1"), eq(USER_ID_STR), anyString(), anyDouble(), anyInt()))
-                .willReturn(Arrays.asList(-1L, "admitted-queue-key", -1L));
+                .willReturn(Arrays.asList(-1L, "admitted-queue-key", -1L, 100L, 50L));
 
         // when
-        QueueRegisterResponse response = queueService.register(USER_ID, request);
+        QueueRegisterResponse response = queueService.register(USER_ID, request, TEST_POLICY);
 
         // then
         assertThat(response.getQueueKey()).isEqualTo("admitted-queue-key");
         assertThat(response.getPosition()).isEqualTo(0);
         assertThat(response.getEtaSeconds()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("등록 - policy가 null이면 기본 admissionRps로 ETA를 계산한다")
+    void register_nullPolicy_fallsBackToDefaultRps() {
+        // given — admissionRps=10, rank=9 → position=10, ETA=10/10=1
+        QueueRegisterRequest request = createRequest("event1");
+        given(queueRedisRepository.registerIdempotent(
+                eq("event1"), eq(USER_ID_STR), anyString(), anyDouble(), anyInt()))
+                .willReturn(Arrays.asList(1L, "new-queue-key", 9L, 100L, 50L));
+
+        // when — policy=null (PolicyFilter를 거치지 않은 경우)
+        QueueRegisterResponse response = queueService.register(USER_ID, request, null);
+
+        // then
+        assertThat(response.getEtaSeconds()).isEqualTo(1); // 10 / default(10)
+    }
+
+    @Test
+    @DisplayName("등록 - policy의 admissionRps가 기본값과 다르면 해당 값으로 ETA를 계산한다")
+    void register_policyOverridesAdmissionRps() {
+        // given — policy admissionRps=50, rank=49 → position=50, ETA=50/50=1
+        PolicyCacheDto customPolicy = new PolicyCacheDto(
+                true, 1L, 50, 0, 1L, null, 0, 10, "ROUTING_ENABLED");
+        QueueRegisterRequest request = createRequest("event1");
+        given(queueRedisRepository.registerIdempotent(
+                eq("event1"), eq(USER_ID_STR), anyString(), anyDouble(), anyInt()))
+                .willReturn(Arrays.asList(1L, "new-queue-key", 49L, 200L, 100L));
+
+        // when
+        QueueRegisterResponse response = queueService.register(USER_ID, request, customPolicy);
+
+        // then — default(10)였으면 ETA=5, policy(50)이면 ETA=1
+        assertThat(response.getEtaSeconds()).isEqualTo(1);
     }
 
     // === getStatus 테스트 ===


### PR DESCRIPTION
## 🔍 What

  배포 환경(Aiven Valkey SSL, RTT ~80ms)에서 `POST /queue/register` 1건당 **8 Redis RTT → 3 RTT**로 줄여 응답 시간을 ~640ms → ~240ms로
  개선합니다.

  ### Before (8 RTTs)
  | # | 위치 | 연산 |
  |---|------|------|
  | 1 | PolicyFilter | `policyCacheRepository.find()` → GET |
  | 2 | PolicyFilter | `redisTemplate.hasKey(blockKey)` → EXISTS |
  | 3 | PolicyFilter | `redisTemplate.increment(rlKey)` → INCR |
  | 4 | PolicyFilter | `redisTemplate.expire(rlKey)` → EXPIRE |
  | 5 | QueueService | `registerIdempotent` Lua → EVAL |
  | 6 | QueueService | `getQueueSize()` → ZCARD |
  | 7 | QueueService | `getAdmittedCount()` → ZCARD |
  | 8 | QueueService | `resolveAdmissionRps()` → GET policy cache |

  ### After (3 RTTs)
  | # | 위치 | 연산 |
  |---|------|------|
  | 1 | PolicyFilter | `policyCacheRepository.find()` → GET |
  | 2 | PolicyFilter | `policy-enforce.lua` (block check + rate limit 통합) |
  | 3 | QueueService | `register-idempotent.lua` (ZCARD 2개 포함 반환) |

  ### 변경 내역

  **신규 Lua 스크립트**
  - `policy-enforce.lua`: EXISTS(blockKey) + INCR/EXPIRE(rlKey) + 조건부 SET(blockKey)을 단일 EVAL로 통합

  **Lua 수정**
  - `register-idempotent.lua`: 모든 return 경로에 `ZCARD(queueKey), ZCARD(admittedKey)` 추가 → metrics용 별도 호출 제거

  **Java 변경**
  - `RedisConfig`: `policyEnforceScript()` 빈 등록
  - `PolicyFilter`: hasKey/increment/expire 3개 호출 → Lua 1회로 교체, `request.setAttribute("policyCache", policy)`로 정책 전달
  - `QueueController`: `HttpServletRequest`에서 PolicyCacheDto 추출 후 서비스에 전달
  - `QueueService`: Lua 반환값으로 metrics 갱신, 전달받은 policy로 admissionRps 조회 → `PolicyCacheRepository` 의존성 제거

  ## 🧪 How to test

  1. 단위 테스트: `./gradlew :test` — QueueServiceTest(15개), PolicyFilterTest(1개) 통과 확인
  2. 배포 후 TTFB 비교:
     curl -w "TTFB: %{time_starttransfer}s" -X POST /queue/register
       -H "Content-Type: application/json" -d '{"eventId":1}'

  ## 🔗 Issue
  - Closes: #139 
---
### ✅ 체크리스트
- [ ] base가 **develop**으로 설정되었나요?
- [ ] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 정책 강제 실행을 Redis 원자 연산으로 통합하여 차단 및 속도 제한 처리 신뢰성·성능 향상
  * 큐 등록 응답에 대기 인원 및 수락 인원 수가 포함되어 대기 상태 가시성 확대
  * 요청별 정책 정보를 흐름에 전달하도록 개선되어 정책 일관성 향상
  * 로그에 민감식별자 마스킹을 적용하여 정보 노출 위험 감소

* **테스트**
  * 정책 전달 흐름 반영 및 반환값 확장에 따른 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->